### PR TITLE
feat(backend): endpoints de produtos e auth + config do MySQL (Docker)

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="marmitapp@localhost" uuid="d4705c04-006c-4b9b-8177-ab96aac4ca75">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/MarmitApp/src/main/resources/application.properties</remarks>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/marmitapp?useTimezone=true&amp;serverTimezone=America/Sao_Paulo&amp;useSSL=false</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/MarmitApp/pom.xml
+++ b/MarmitApp/pom.xml
@@ -60,6 +60,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/MarmitApp/src/main/java/com/example/marmitapp/config/SecurityBeans.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/config/SecurityBeans.java
@@ -1,0 +1,14 @@
+package com.example.marmitapp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityBeans {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/controller/AuthController.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.example.marmitapp.controller;
+
+import com.example.marmitapp.dto.AuthDtos;
+import com.example.marmitapp.model.Usuario;
+import com.example.marmitapp.repository.UsuarioRepository;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+@CrossOrigin(origins = "http://localhost:5173")
+public class AuthController {
+    private final UsuarioRepository repo;
+    private final PasswordEncoder encoder;
+    public AuthController(UsuarioRepository r, PasswordEncoder e){ this.repo=r; this.encoder=e; }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@Valid @RequestBody AuthDtos.RegisterReq body) {
+        if (repo.findByEmail(body.email()).isPresent())
+            return ResponseEntity.badRequest().body(Map.of("error","E-mail já cadastrado"));
+        var u = new Usuario(body.nome(), body.email(), encoder.encode(body.senha()));
+        repo.save(u);
+        return ResponseEntity.ok(new AuthDtos.UserRes(u.getId(), u.getNome(), u.getEmail()));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody AuthDtos.LoginReq body) {
+        var u = repo.findByEmail(body.email())
+                .filter(user -> encoder.matches(body.senha(), user.getSenhaHash()))
+                .orElse(null);
+        if (u == null) return ResponseEntity.status(401).body(Map.of("error","Credenciais inválidas"));
+        return ResponseEntity.ok(new AuthDtos.UserRes(u.getId(), u.getNome(), u.getEmail()));
+    }
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/controller/PingController.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/controller/PingController.java
@@ -1,0 +1,10 @@
+package com.example.marmitapp.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+public class PingController {
+    @GetMapping("/ping")
+    public String ping() { return "ok"; }
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/controller/ProdutoController.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/controller/ProdutoController.java
@@ -1,0 +1,36 @@
+package com.example.marmitapp.controller;
+
+import com.example.marmitapp.model.Produto;
+import com.example.marmitapp.repository.ProdutoRepository;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/produtos")
+@CrossOrigin(origins = "http://localhost:5173")
+public class ProdutoController {
+
+    private final ProdutoRepository repo;
+
+    public ProdutoController(ProdutoRepository repo) {
+        this.repo = repo;
+    }
+
+    @GetMapping
+    public List<Produto> listar() {
+        return repo.findAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<Produto> criar(@Valid @RequestBody Produto p) {
+        if (p.getPreco() == null) p.setPreco(new BigDecimal("0"));
+        if (p.getEstoque() == null) p.setEstoque(0);
+        Produto salvo = repo.save(p);
+        return ResponseEntity.created(URI.create("/produtos/" + salvo.getId())).body(salvo);
+    }
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/dto/AuthDtos.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/dto/AuthDtos.java
@@ -1,0 +1,15 @@
+package com.example.marmitapp.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class AuthDtos {
+    public record RegisterReq(@NotBlank String nome,
+                              @Email @NotBlank String email,
+                              @NotBlank String senha) {}
+
+    public record LoginReq(@Email @NotBlank String email,
+                           @NotBlank String senha) {}
+
+    public record UserRes(Long id, String nome, String email) {}
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/model/Produto.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/model/Produto.java
@@ -1,0 +1,34 @@
+package com.example.marmitapp.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "produto")
+public class Produto {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String nome;
+
+    @Positive
+    private BigDecimal preco;
+
+    @Min(0)
+    private Integer estoque;
+
+    public Produto() {}
+    public Produto(String nome, BigDecimal preco, Integer estoque) {
+        this.nome = nome; this.preco = preco; this.estoque = estoque;
+    }
+
+    public Long getId() { return id; }
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
+    public BigDecimal getPreco() { return preco; }
+    public void setPreco(BigDecimal preco) { this.preco = preco; }
+    public Integer getEstoque() { return estoque; }
+    public void setEstoque(Integer estoque) { this.estoque = estoque; }
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/model/Usuario.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/model/Usuario.java
@@ -1,0 +1,40 @@
+package com.example.marmitapp.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+@Table(name = "usuario")
+public class Usuario {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String nome;
+
+    @Email
+    @NotBlank
+    @Column(unique = true)
+    private String email;
+
+    @NotBlank
+    private String senhaHash;
+
+    public Usuario() {}
+
+    public Usuario(String nome, String email, String senhaHash) {
+        this.nome = nome;
+        this.email = email;
+        this.senhaHash = senhaHash;
+    }
+
+    public Long getId() { return id; }
+    public String getNome() { return nome; }
+    public void setNome(String nome) { this.nome = nome; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getSenhaHash() { return senhaHash; }
+    public void setSenhaHash(String senhaHash) { this.senhaHash = senhaHash; }
+}

--- a/MarmitApp/src/main/java/com/example/marmitapp/repository/ProdutoRepository.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/repository/ProdutoRepository.java
@@ -1,0 +1,7 @@
+package com.example.marmitapp.repository;
+
+
+import com.example.marmitapp.model.Produto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProdutoRepository extends JpaRepository<Produto, Long> {}

--- a/MarmitApp/src/main/java/com/example/marmitapp/repository/UsuarioRepository.java
+++ b/MarmitApp/src/main/java/com/example/marmitapp/repository/UsuarioRepository.java
@@ -1,0 +1,10 @@
+package com.example.marmitapp.repository;
+
+import com.example.marmitapp.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+    Optional<Usuario> findByEmail(String email);
+}

--- a/MarmitApp/src/main/resources/application.properties
+++ b/MarmitApp/src/main/resources/application.properties
@@ -1,11 +1,12 @@
+server.port=8080
 spring.application.name=MarmitApp
 
-# Conexão com MySQL
-spring.datasource.url=jdbc:mysql://localhost:3306/marmitapp?useTimezone=true&serverTimezone=America/Sao_Paulo&useSSL=false
+spring.datasource.url=jdbc:mysql://localhost:3307/marmitapp?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=America/Sao_Paulo
 spring.datasource.username=root
 spring.datasource.password=root
 
-# JPA / Hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always


### PR DESCRIPTION
## O que foi feito
- Auth:
  - `POST /auth/register` (hash de senha, validação)
  - `POST /auth/login` (retorna dados básicos do usuário)
- Produtos:
  - `GET /produtos` (lista)
  - `POST /produtos` (criação com validações)
- JPA: entidades `Usuario` e `Produto`, repositórios
- Config:
  - MySQL via Docker (`marmitapp-mysql`)
  - `application.properties` apontando para o container
  - CORS liberado para `http://localhost:5173`
- Tratamento simples de erros (400/404)
- README com instruções de execução

## Como rodar
1. Subir banco:
   ```bash
   docker start marmitapp-mysql || \
   docker run --name marmitapp-mysql -d -e MYSQL_ROOT_PASSWORD=root \
     -e MYSQL_DATABASE=marmitapp -p 3307:3306 mysql:8
